### PR TITLE
session 3845 reboot retry

### DIFF
--- a/sessions/3845/data.json
+++ b/sessions/3845/data.json
@@ -6,10 +6,10 @@
         "start_time_iso_with_zone": "2020-07-19T00:56:21+02:00", 
         "stop_time_iso_with_zone": "2020-07-19T01:04:01+02:00", 
         "maximum_elevation": 5.3, 
-        "status": "auto", 
+        "status": "planned", 
         "session_tasks": [
-            "sleep-beacon"
+            "refresh-deep-sleep"
         ], 
-        "short_description": ""
+        "short_description": "Refresh Deep Sleep"
     }
 }


### PR DESCRIPTION
Poprzedni reboot nie wyszedł, bootslotsy ustawione. Ta sesja będzie polegała na wysyłaniu powercycla aż usłyszy.